### PR TITLE
Bump snapshot and use http-client >= 0.5

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -2,13 +2,14 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration/
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-5.12
+resolver: lts-7.14
 
 # Local packages, usually specified by relative directory name
 packages:
 - '.'
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps: []
+extra-deps:
+- http-client-0.5.4
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
This package depends on `http-client >= 0.5` but this is not found in any snapshot so I added it to extra-deps. While I was at it I also bumped the resolver.