### PR TITLE
Implement ping

### DIFF
--- a/influxdb.cabal
+++ b/influxdb.cabal
@@ -33,6 +33,7 @@ library
     Database.InfluxDB.JSON
     Database.InfluxDB.Line
     Database.InfluxDB.Manage
+    Database.InfluxDB.Ping
     Database.InfluxDB.Query
     Database.InfluxDB.Types
     Database.InfluxDB.Write
@@ -66,6 +67,7 @@ library
     , aeson >= 0.7 && < 1.1
     , attoparsec < 0.14
     , bytestring >= 0.10 && < 0.11
+    , clock >= 0.7 && < 0.8
     , containers >= 0.5 && < 0.6
     , foldl < 1.3
     , http-types >= 0.8.6 && < 0.10

--- a/src/Database/InfluxDB/Ping.hs
+++ b/src/Database/InfluxDB/Ping.hs
@@ -1,6 +1,101 @@
-module Database.InfluxDB.Ping (ping) where
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
 
-import Database.InfluxDB.Types
+module Database.InfluxDB.Ping
+  (
+  -- * Ping interface
+    ping
 
-ping :: Server -> IO Bool
-ping Server {..} = do
+  -- * Ping parameters
+  , PingParams(..)
+  , pingParams
+  , Types.server
+  , Types.manager
+  , waitForLeader
+
+  -- * Ping result
+  , PingResult(..)
+  , roundtripTime
+  , influxdbVersion
+  ) where
+
+import Control.Lens
+import qualified Data.ByteString as BS
+import qualified Data.Text.Encoding as TE
+import qualified Network.HTTP.Client.Compat as HC
+import System.Clock
+
+import Database.InfluxDB.Types as Types
+
+
+-- Ping requests do not require authentication
+-- | The full set of parameters for the ping API
+data PingParams = PingParams
+  { _server :: !Server
+  , _manager :: !(Either HC.ManagerSettings HC.Manager)
+  -- ^ HTTP connection manager
+  , _waitForLeader :: !(Maybe Int)
+  -- ^ the number of seconds to wait
+  }
+
+makeLensesWith (lensRules & generateSignatures .~ False) ''PingParams
+
+server :: Lens' PingParams Server
+
+instance HasServer PingParams where
+  server = Database.InfluxDB.Ping.server
+
+manager :: Lens' PingParams (Either HC.ManagerSettings HC.Manager)
+
+instance HasManager PingParams where
+  manager = Database.InfluxDB.Ping.manager
+
+-- | The number of seconds to wait before returning a response
+waitForLeader :: Lens' PingParams (Maybe Int)
+
+pingParams :: PingParams
+pingParams =
+  PingParams
+  { _server = localServer
+  , _manager = Left HC.defaultManagerSettings
+  , _waitForLeader = Nothing
+  }
+
+pingRequest :: PingParams -> HC.Request
+pingRequest PingParams {..} = HC.defaultRequest
+  { HC.host = TE.encodeUtf8 _host
+  , HC.port = fromIntegral _port
+  , HC.secure = _ssl
+  , HC.method = "GET"
+  , HC.path = "/ping"
+  }
+  where
+    Server {..} = _server
+
+data PingResult = PingResult
+  { _roundtripTime :: !TimeSpec
+  , _influxdbVersion :: !BS.ByteString
+  } deriving (Show, Eq, Ord)
+
+makeLensesWith (lensRules & generateSignatures .~ False) ''PingResult
+
+-- | Roundtrip time of the ping
+roundtripTime :: Lens' PingResult TimeSpec
+
+-- | Version string returned by the InfluxDB header
+influxdbVersion :: Lens' PingResult BS.ByteString
+
+ping :: PingParams -> IO PingResult
+ping params = do
+  manager' <- either HC.newManager return $ _manager params
+  startTime <- getTime'
+  HC.withResponse request manager' (\response -> do
+    endTime <- getTime'
+    let headers = HC.responseHeaders response
+    case lookup "X-Influxdb-Version" headers of
+      Just version -> pure (PingResult (diffTimeSpec endTime startTime) version)
+      Nothing -> error "A response by influxdb should always contain a version header.")
+  where
+    request = pingRequest params
+    getTime' = getTime Monotonic


### PR DESCRIPTION
This is more of an RFC than a finished PR.

Let me point out a few specific points that are perhaps controversial or where I am not sure how to handle something:

* This adds a dependency on the `clock` package. Without this package there is not really a way to get a monotonic clock which you really want in this case. `clock` doesn’t have any other dependencies and seems to be reasonably well maintained and is in stackage.
* I included the influxdb version number in the response. Technically this is returned in every response but since `ping` is more targeted towards debugging and monitoring it makes sense to include it here even if it is not included in other places.
* This is the most tricky part: Error handling. The use of `error` is probably fairly safe unless you are talking to something that is not influxdb. The remaining errors are 
1. Responses that fail completely. In this case `http-client` will throw an exception just like for any other request made by this package so that’s probably fine.
2. Responses that return a non `2xx` status code. This case is tricky because the behavior of `http-client` changed starting from `0.5`. Prior versions throw an exception in that case, however starting from `0.5` that is no longer the case (at least not in the way it is used in this package afaict). So one would need to check for these cases and return a different response. This is *not* specific to `ping`. I think there are two solutions here: Either we use `http-client` in a way that always throws exceptions on non `2xx` status codes or we actually handle this case and wrap all responses in an `Either Error`. In the latter case it would make sense to drop support for `http-client < 0.5`.