### PR TITLE
Take into account the nullability of Field

### DIFF
--- a/examples/random-points.hs
+++ b/examples/random-points.hs
@@ -96,7 +96,7 @@ data Name
   | Qux
   deriving (Enum, Bounded, Show)
 
-nameToFVal :: Name -> FieldValue
+nameToFVal :: Name -> LineField
 nameToFVal = FieldString . T.toLower . T.pack . show
 
 instance Variate Name where

--- a/src/Database/InfluxDB.hs
+++ b/src/Database/InfluxDB.hs
@@ -23,7 +23,9 @@ module Database.InfluxDB
   , fieldSet
   , timestamp
 
-  , FieldValue(..)
+  , Field(..)
+  , LineField
+  , QueryField
   , Timestamp(..)
   , precisionScale
   , precisionName

--- a/src/Database/InfluxDB/Format.hs
+++ b/src/Database/InfluxDB/Format.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Database.InfluxDB.Format
@@ -86,7 +85,7 @@ key = makeFormat keyBuilder
 keys :: Format r ([Key] -> r)
 keys = makeFormat $ mconcat . L.intersperse "," . map keyBuilder
 
-fieldVal :: Format r (FieldValue -> r)
+fieldVal :: Format r (QueryField -> r)
 fieldVal = makeFormat $ \case
   FieldInt n -> TL.decimal n
   FieldFloat d -> TL.realFloat d

--- a/src/Database/InfluxDB/JSON.hs
+++ b/src/Database/InfluxDB/JSON.hs
@@ -2,10 +2,8 @@
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE ViewPatterns #-}
 module Database.InfluxDB.JSON
   ( parseResultsWith
@@ -194,7 +192,7 @@ parseRFC3339 val = A.withText err
     fmt = "%FT%X%QZ"
     err = "RFC3339-formatted timestamp"
 
-parseFieldValue :: A.Value -> A.Parser FieldValue
+parseFieldValue :: A.Value -> A.Parser QueryField
 parseFieldValue val = case val of
   A.Number sci ->
     return $! either FieldFloat FieldInt $ Sci.floatingOrInteger sci

--- a/src/Database/InfluxDB/Line.hs
+++ b/src/Database/InfluxDB/Line.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -41,7 +40,7 @@ data Line time = Line
   -- ^ Measurement name
   , _tagSet :: !(Map Key Text)
   -- ^ Set of tags (optional)
-  , _fieldSet :: !(Map Key FieldValue)
+  , _fieldSet :: !(Map Key LineField)
   -- ^ Set of fields
   --
   -- It shouldn't be empty.
@@ -91,13 +90,12 @@ buildKey = TE.encodeUtf8Builder . escapeKey
 escapeKey :: Key -> Text
 escapeKey (Key text) = T.replace " " "\\ " $ T.replace "," "\\," text
 
-buildFieldValue :: FieldValue -> B.Builder
+buildFieldValue :: LineField -> B.Builder
 buildFieldValue = \case
   FieldInt i -> B.int64Dec i <> "i"
   FieldFloat d -> B.doubleDec d
   FieldString t -> "\"" <> TE.encodeUtf8Builder t <> "\""
   FieldBool b -> if b then "true" else "false"
-  FieldNull -> "null"
 
 buildLines
   :: Foldable f
@@ -117,7 +115,7 @@ tagSet :: Lens' (Line time) (Map Key Text)
 
 -- | Field(s) for your data point. Every data point requires at least one field
 -- in the Line Protocol, so it shouldn't be 'empty'.
-fieldSet :: Lens' (Line time) (Map Key FieldValue)
+fieldSet :: Lens' (Line time) (Map Key LineField)
 
 -- | Timestamp for your data point. You can put whatever type of timestamp that
 -- is an instance of the 'Timestamp' class.


### PR DESCRIPTION
Fixes #44.

The line protocol doesn't allow null fields whereas query results may contain them. This change introduces the `Nullability` type and use it as a constraint on the `FieldNull` constructor.

This is a breaking change:

* `FieldValue` has been renamed to `Field` with the nullability parameter.
* `Data` and `Generic` instances for `Field` have been dropped.