### PR TITLE
Add Haddock comments and tidy up API

### DIFF
--- a/examples/random-points.hs
+++ b/examples/random-points.hs
@@ -77,7 +77,7 @@ data Row = Row
 
 instance QueryResults Row where
   parseResults prec = parseResultsWith $ \_ _ columns fields -> do
-    rowTime <- getField "time" columns fields >>= parseTimestamp prec
+    rowTime <- getField "time" columns fields >>= parsePOSIXTime prec
     String name <- getField "value" columns fields
     rowValue <- case name of
       "foo" -> return Foo

--- a/src/Database/InfluxDB.hs
+++ b/src/Database/InfluxDB.hs
@@ -31,11 +31,13 @@ module Database.InfluxDB
   , precisionName
 
   -- * Querying data
+  -- $query
   , Query
   , query
   , queryChunked
 
-  -- * Query constructor
+  -- ** Query construction
+  -- $query-construction
   , formatQuery
   , (%)
 
@@ -45,13 +47,14 @@ module Database.InfluxDB
   , authentication
 
   -- ** Parsing results
+  -- $parsing-results
   , QueryResults(..)
   , parseResultsWith
   , getField
   , getTag
-  , parseTimestamp
-  , parseFieldValue
-  , parseKey
+  , parseUTCTime
+  , parsePOSIXTime
+  , parseQueryField
 
   -- * Database management
   , manage
@@ -65,7 +68,7 @@ module Database.InfluxDB
   , host
   , port
   , ssl
-  , localServer
+  , defaultServer
 
   , Credentials
   , credentials
@@ -96,5 +99,21 @@ import:
 
 @
 import qualified "Database.InfluxDB.Write.UDP" as UDP
+@
+-}
+
+{- $query
+'query' and 'queryChunked' can be used to query data. If your dataset fits your
+memory, 'query' is easier to use. If it doesn't, use 'queryChunked' to stream
+data.
+-}
+
+{- $query-construction
+There are various utility functions available in "Database.InfluxDB.Format".
+This module is designed to be imported as qualified:
+
+@
+import "Database.InfluxDB"
+import qualified "Database.InfluxDB.Format" as F
 @
 -}

--- a/src/Database/InfluxDB.hs
+++ b/src/Database/InfluxDB.hs
@@ -92,6 +92,85 @@ import Database.InfluxDB.Query
 import Database.InfluxDB.Types
 import Database.InfluxDB.Write
 
+{- $intro
+= Getting started
+
+This tutorial assumes the following language extensions and imports.
+
+>>> :set -XOverloadedStrings
+>>> :set -XRecordWildCards
+>>> import Database.InfluxDB
+>>> import qualified Database.InfluxDB.Format as F
+>>> import Control.Lens
+>>> import qualified Data.Map as Map
+>>> import Data.Time
+>>> import qualified Data.Vector as V
+
+The examples below roughly follows the
+ [README](https://github.com/influxdata/influxdb/blob/0b4528b26de43d5504ec0623c184540f7c3e1a54/client/README.md)
+in the official Go client library.
+
+== Creating a database
+
+This library assumes the [lens](https://hackage.haskell.org/package/lens)
+package in some APIs. Here we use 'Control.Lens.?~' to set the authentication
+parameters of type @Maybe 'Credentials'@.
+
+Also note that in order to construct a 'Query', we use 'formatQuery' with the
+'F.database' formatter. There are many other formatter defined in
+"Database.InfluxDB.Format".
+
+>>> let db = "square_holes"
+>>> let bubba = credentials "bubba" "bumblebeetuna"
+>>> let p = queryParams db & authentication ?~ bubba
+>>> manage p $ formatQuery ("CREATE DATABASE "%F.database) db
+
+== Writing data
+
+'write' or 'writeBatch' can be used to write data. In general 'writeBatch'
+should be used for efficiency when writing multiple data points.
+
+>>> let wp = writeParams db & authentication ?~ bubba & precision .~ Second
+>>> let cpuUsage = "cpu_usage"
+>>> :{
+writeBatch wp
+  [ Line cpuUsage (Map.singleton "cpu" "cpu-total")
+    (Map.fromList
+      [ ("idle",   FieldFloat 10.1)
+      , ("system", FieldFloat 53.3)
+      , ("user",   FieldFloat 46.6)
+      ])
+    (Nothing :: Maybe UTCTime)
+  ]
+
+Note that the type signature of the timestamp is necessary. Otherwise it doesn't
+type check.
+
+== Querying data
+
+First we define a placeholder data type called 'CPUUsage' and a 'QueryResults'
+instance. 'getField', 'parseUTCTime' and 'parseQueryField' etc are avilable to
+make JSON decoding easier.
+
+>>> :{
+data CPUUsage = CPUUsage
+  { time :: UTCTime
+  , cpuIdle, cpuSystem, cpuUser :: Double
+  } deriving Show
+instance QueryResults CPUUsage where
+  parseResults prec = parseResultsWithDecoder strictDecoder $ \_ _ columns fields -> do
+    time <- getField "time" columns fields >>= parseUTCTime prec
+    FieldFloat cpuIdle <- getField "idle" columns fields >>= parseQueryField
+    FieldFloat cpuSystem <- getField "system" columns fields >>= parseQueryField
+    FieldFloat cpuUser <- getField "user" columns fields >>= parseQueryField
+    return CPUUsage {..}
+:}
+>>> query p $ formatQuery ("SELECT * FROM "%F.key) cpuUsage :: IO (V.Vector CPUUsage)
+[CPUUsage {time = 2017-06-17 15:41:40.52659044 UTC, cpuIdle = 10.1, cpuSystem = 53.3, cpuUser = 46.6}]
+
+Note that the type signature on query here is also necessary to type check.
+-}
+
 {- $write
 InfluxDB has two ways to write data into it, via HTTP and UDP. This module
 only exports functions for the HTTP API. For UDP, you can use a qualified

--- a/src/Database/InfluxDB/Format.hs
+++ b/src/Database/InfluxDB/Format.hs
@@ -2,16 +2,17 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Database.InfluxDB.Format
-  ( Query
-  , fromQuery
-
-  , Format
+  ( -- * The 'Format' type and associated functions
+    Format
   , makeFormat
   , (%)
+
+  -- * Formatting functions
   , formatQuery
   , formatDatabase
   , formatKey
 
+  -- * Formatters for various types
   , database
   , key
   , keys
@@ -22,6 +23,9 @@ module Database.InfluxDB.Format
   , string
   , byteString8
   , time
+
+  -- * Utility functions
+  , fromQuery
   ) where
 import Control.Category
 import Data.Monoid
@@ -42,12 +46,35 @@ import qualified Data.Text.Lazy.Builder.RealFloat as TL
 
 import Database.InfluxDB.Types hiding (database)
 
+-- $setup
+-- >>> :set -XOverloadedStrings
+
+-- | Serialize a 'Query' to a 'B.ByteString'.
 fromQuery :: Query -> B.ByteString
 fromQuery (Query q) =
   BL.toStrict $ BL.toLazyByteString $ T.encodeUtf8Builder q
 
-newtype Format a b = Format { runFormat :: (TL.Builder -> a) -> b }
+-- | A typed format string. @Format a r@ means that @a@ is the type of formatted
+-- string, and @r@ is the type of the formatter.
+--
+-- >>> :t formatQuery
+-- formatQuery :: Format Query r -> r
+-- >>> :t key
+-- key :: Format r (Key -> r)
+-- >>> :t "SELECT * FROM "%key
+-- "SELECT * FROM "%key :: Format a (Key -> a)
+-- >>> :t formatQuery ("SELECT * FROM "%key)
+-- formatQuery ("SELECT * FROM "%key) :: Key -> Query
+-- >>> formatQuery ("SELECT * FROM "%key) "series"
+-- "SELECT * FROM \"series\""
+newtype Format a r = Format { runFormat :: (TL.Builder -> a) -> r }
 
+-- | 'Format's can be composed using @('.')@ from "Control.Category".
+--
+-- >>> import Control.Category ((.))
+-- >>> import Prelude hiding ((.))
+-- >>> formatQuery ("SELECT * FROM " . key) "series"
+-- "SELECT * FROM \"series\""
 instance Category Format where
   id = Format (\k -> k "")
   fmt1 . fmt2 = Format $ \k ->
@@ -55,36 +82,76 @@ instance Category Format where
       runFormat fmt2 $ \b ->
         k (a <> b)
 
-instance a ~ b => IsString (Format a b) where
+-- | With the OverloadedStrings exension, string literals can be used to write
+-- queries.
+--
+-- >>> "SELECT * FROM series" :: Query
+-- "SELECT * FROM series"
+instance a ~ r => IsString (Format a r) where
   fromString xs = Format $ \k -> k $ fromString xs
 
+-- | 'Format' specific synonym of @('.')@.
+--
+-- This is typically easier to use than @('.')@ is because it doesn't
+-- conflict with @Prelude.(.)@.
 (%) :: Format b c -> Format a b -> Format a c
 (%) = (.)
 
+-- | Format a 'Query'.
+--
+-- >>> formatQuery "SELECT * FROM series"
+-- "SELECT * FROM series"
+-- >>> formatQuery ("SELECT * FROM "%key) "series"
+-- "SELECT * FROM \"series\""
 formatQuery :: Format Query r -> r
 formatQuery fmt = runFormat fmt (Query . TL.toStrict . TL.toLazyText)
 
+-- | Format a 'Database'.
+--
+-- >>> formatDatabase "test-db"
+-- "test-db"
 formatDatabase :: Format Database r -> r
 formatDatabase fmt = runFormat fmt (Database . TL.toStrict . TL.toLazyText)
 
+-- | Format a 'Key'.
+--
+-- >>> formatKey "test-key"
+-- "test-key"
 formatKey :: Format Key r -> r
 formatKey fmt = runFormat fmt (Key . TL.toStrict . TL.toLazyText)
 
+-- | Convenience function to make a custom formatter.
 makeFormat :: (a -> TL.Builder) -> Format r (a -> r)
 makeFormat build = Format $ \k a -> k $ build a
 
+-- | Format a database name.
+--
+-- >>> formatQuery ("CREATE DATABASE "%database) "test-db"
+-- "CREATE DATABASE \"test-db\""
 database :: Format r (Database -> r)
 database = makeFormat $ \(Database name) -> "\"" <> TL.fromText name <> "\""
 
 keyBuilder :: Key -> TL.Builder
 keyBuilder (Key name) = "\"" <> TL.fromText name <> "\""
 
+-- | Format a key (e.g. series names, field names etc).
+--
+-- >>> formatQuery ("SELECT * FROM "%key) "test-series"
+-- "SELECT * FROM \"test-series\""
 key :: Format r (Key -> r)
 key = makeFormat keyBuilder
 
+-- | Format multiple keys.
+--
+-- >>> formatQuery ("SELECT "%keys%" FROM series") ["field1", "field2"]
+-- "SELECT \"field1\",\"field2\" FROM series"
 keys :: Format r ([Key] -> r)
 keys = makeFormat $ mconcat . L.intersperse "," . map keyBuilder
 
+-- | Format 'QueryField'.
+--
+-- >>> formatQuery ("SELECT * FROM series WHERE "%key%" = "%fieldVal) "location" "tokyo"
+-- "SELECT * FROM series WHERE \"location\" = 'tokyo'"
 fieldVal :: Format r (QueryField -> r)
 fieldVal = makeFormat $ \case
   FieldInt n -> TL.decimal n
@@ -93,21 +160,56 @@ fieldVal = makeFormat $ \case
   FieldBool b -> if b then "true" else "false"
   FieldNull -> "null"
 
+-- | Format a decimal number.
+--
+-- >>> formatQuery ("SELECT * FROM series WHERE time < now() - "%decimal%"h") 1
+-- "SELECT * FROM series WHERE time < now() - 1h"
 decimal :: Integral a => Format r (a -> r)
 decimal = makeFormat TL.decimal
 
+-- | Format a floating-point number.
+--
+-- >>> formatQuery ("SELECT * FROM series WHERE value > "%realFloat) 0.1
+-- "SELECT * FROM series WHERE value > 0.1"
 realFloat :: RealFloat a => Format r (a -> r)
 realFloat = makeFormat TL.realFloat
 
+-- | Format a text.
+--
+-- Note that this doesn't escape the string. Use 'fieldKey' to format field
+-- values in a query.
+--
+-- >>> :t formatKey text
+-- formatKey text :: T.Text -> Key
 text :: Format r (T.Text -> r)
 text = makeFormat TL.fromText
 
+-- | Format a string.
+--
+-- Note that this doesn't escape the string. Use 'fieldKey' to format field
+-- values in a query.
+--
+-- >>> :t formatKey string
+-- formatKey string :: String -> Key
 string :: Format r (String -> r)
 string = makeFormat TL.fromString
 
+-- | Format a UTF-8 encoded byte string.
+--
+-- Note that this doesn't escape the string. Use 'fieldKey' to format field
+-- values in a query.
+--
+-- >>> :t formatKey byteString8
+-- formatKey byteString8 :: B.ByteString -> Key
 byteString8 :: Format r (B.ByteString -> r)
 byteString8 = makeFormat $ TL.fromText . T.decodeUtf8
 
+-- | Format a time.
+--
+-- >>> import Data.Time
+-- >>> let Just t = parseTimeM False defaultTimeLocale "%s" "0" :: Maybe UTCTime
+-- >>> formatQuery ("SELECT * FROM series WHERE time >= "%time) t
+-- "SELECT * FROM series WHERE time >= '1970-01-01 00:00:00'"
 time :: FormatTime time => Format r (time -> r)
 time = makeFormat $ \t ->
   "'" <> TL.fromString (formatTime defaultTimeLocale fmt t) <> "'"

--- a/src/Database/InfluxDB/Line.hs
+++ b/src/Database/InfluxDB/Line.hs
@@ -33,7 +33,7 @@ import Database.InfluxDB.Types
 
 -- | Placeholder for the Line Protocol
 --
--- See https://docs.influxdata.com/influxdb/v1.0/write_protocols/line_protocol_tutorial/ for the
+-- See https://docs.influxdata.com/influxdb/v1.2/write_protocols/line_protocol_tutorial/ for the
 -- concrete syntax.
 data Line time = Line
   { _measurement :: !Key

--- a/src/Database/InfluxDB/Manage.hs
+++ b/src/Database/InfluxDB/Manage.hs
@@ -1,17 +1,35 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+#if __GLASGOW_HASKELL__ >= 800
+{-# OPTIONS_GHC -Wno-missing-signatures #-}
+#else
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
+#endif
 module Database.InfluxDB.Manage
-  ( manage
+  ( -- * Management query interface
+    Query
+  , manage
 
+  -- * Query parameters
+  , QueryParams
+  , queryParams
+  , server
+  , database
+  , precision
+  , manager
+
+  -- * Management query results
+  -- ** SHOW QUERIES
   , ShowQuery
   , qid
   , queryText
-  , Types.database
   , duration
 
+  -- ** SHOW SERIES
   , ShowSeries
   , key
   ) where
@@ -33,18 +51,28 @@ import qualified Data.Vector as V
 import qualified Network.HTTP.Client as HC
 import qualified Network.HTTP.Types as HT
 
+import Database.InfluxDB.JSON (getField, parseQueryField)
 import Database.InfluxDB.Types as Types
 import Database.InfluxDB.Query hiding (query)
 import qualified Database.InfluxDB.Format as F
 
+-- $setup
+-- >>> :set -XOverloadedStrings
+-- >>> import Database.InfluxDB.Query
+-- >>> import Database.InfluxDB.Format ((%))
+
 -- | Send a database management query to InfluxDB.
+--
+-- >>> let db = "manage-test"
+-- >>> let p = queryParams db
+-- >>> manage p $ F.formatQuery ("CREATE DATABASE "%F.database) db
 manage :: QueryParams -> Query -> IO ()
 manage params q = do
   manager' <- either HC.newManager return $ params^.manager
   response <- HC.httpLbs request manager' `catch` (throwIO . HTTPException)
   let body = HC.responseBody response
   case eitherDecode' body of
-    Left message -> do
+    Left message ->
       throwIO $ IllformedJSON message body
     Right val -> case A.parse (parseResults (params^.precision)) val of
       A.Success (_ :: V.Vector Void) -> return ()
@@ -72,23 +100,25 @@ manageRequest params = HC.defaultRequest
   where
     Server {..} = params^.server
 
+-- |
+-- >>> v <- query (queryParams "_internal") "SHOW QUERIES" :: IO (V.Vector ShowQuery)
 data ShowQuery = ShowQuery
-  { _qid :: !Int
-  , _queryText :: !Query
-  , _database :: !Database
-  , _duration :: !NominalDiffTime
-  } deriving Show
+  { showQueryQid :: !Int
+  , showQueryText :: !Query
+  , showQueryDatabase :: !Database
+  , showQueryDuration :: !NominalDiffTime
+  }
 
 instance QueryResults ShowQuery where
   parseResults _ = parseResultsWith $ \_ _ columns fields ->
     maybe (fail "parseResults: parse error") return $ do
-      Number (toBoundedInteger -> Just _qid) <-
+      Number (toBoundedInteger -> Just showQueryQid) <-
         V.elemIndex "qid" columns >>= V.indexM fields
-      String (F.formatQuery F.text -> _queryText) <-
+      String (F.formatQuery F.text -> showQueryText) <-
         V.elemIndex "query" columns >>= V.indexM fields
-      String (F.formatDatabase F.text -> _database) <-
+      String (F.formatDatabase F.text -> showQueryDatabase) <-
         V.elemIndex "database" columns >>= V.indexM fields
-      String (parseDuration -> Right _duration) <-
+      String (parseDuration -> Right showQueryDuration) <-
         V.elemIndex "duration" columns >>= V.indexM fields
       return ShowQuery {..}
 
@@ -110,49 +140,57 @@ parseDuration = AT.parseOnly $ sum <$!> durations
 
 newtype ShowSeries = ShowSeries
   { _key :: Key
-  } deriving Show
+  }
 
 instance QueryResults ShowSeries where
-  parseResults _ = parseResultsWith $ \_ _ columns fields ->
-    ShowSeries <$> parseKey "key" columns fields
+  parseResults _ = parseResultsWith $ \_ _ columns fields -> do
+    FieldString name <- getField "key" columns fields >>= parseQueryField
+    return $ ShowSeries $ F.formatKey F.text name
 
-makeLensesWith (lensRules & generateSignatures .~ False) ''ShowQuery
+makeLensesWith
+  ( lensRules
+    & generateSignatures .~ False
+    & lensField .~ lookingupNamer
+      [ ("showQueryQid", "qid")
+      , ("showQueryText", "queryText")
+      , ("showQueryDatabase", "_database")
+      , ("showQueryDuration", "duration")
+      ]
+  ) ''ShowQuery
 
 -- | Query ID
 --
--- >>> v <- query (queryParams "_internal") "SHOW QUERIES" :: IO (V.Vector ShowQuery)
--- >>> v ^.. each.qid
--- [149250]
+-- >> v <- query (queryParams "_internal") "SHOW QUERIES" :: IO (V.Vector ShowQuery)
+-- >> v ^.. each.qid
+-- >[149250]
 qid :: Lens' ShowQuery Int
 
 -- | Query text
 --
--- >>> v <- query (queryParams "_internal") "SHOW QUERIES" :: IO (V.Vector ShowQuery)
--- >>> v ^.. each.queryText
--- ["SHOW QUERIES"]
+-- >> v <- query (queryParams "_internal") "SHOW QUERIES" :: IO (V.Vector ShowQuery)
+-- >> v ^.. each.queryText
+-- >["SHOW QUERIES"]
 queryText :: Lens' ShowQuery Query
 
-database :: Lens' ShowQuery Database
-
 -- |
--- >>> v <- query (queryParams "_internal") "SHOW QUERIES" :: IO (V.Vector ShowQuery)
--- >>> v ^.. each.database
--- ["_internal"]
+-- >> v <- query (queryParams "_internal") "SHOW QUERIES" :: IO (V.Vector ShowQuery)
+-- >> v ^.. each.database
+-- >["_internal"]
 instance HasDatabase ShowQuery where
-  database = Database.InfluxDB.Manage.database
+  database = _database
 
 -- | Duration of the query
 --
--- >>> v <- query (queryParams "_internal") "SHOW QUERIES" :: IO (V.Vector ShowQuery)
--- >>> v ^.. each.duration
--- [0.06062s]
+-- >> v <- query (queryParams "_internal") "SHOW QUERIES" :: IO (V.Vector ShowQuery)
+-- >> v ^.. each.duration
+-- >[0.06062s]
 duration :: Lens' ShowQuery NominalDiffTime
 
 makeLensesWith (lensRules & generateSignatures .~ False) ''ShowSeries
 
 -- | Series name
 --
--- >>> v <- query (queryParams "_internal") "SHOW SERIES" :: IO (V.Vector ShowSeries)
--- >>> length $ v ^.. each.key
--- 755
+-- >> v <- query (queryParams "_internal") "SHOW SERIES" :: IO (V.Vector ShowSeries)
+-- >> length $ v ^.. each.key
+-- >755
 key :: Lens' ShowSeries Key

--- a/src/Database/InfluxDB/Query.hs
+++ b/src/Database/InfluxDB/Query.hs
@@ -19,27 +19,26 @@ module Database.InfluxDB.Query
   -- * Query parameters
   , QueryParams
   , queryParams
-  , Types.server
-  , Types.database
-  , Types.precision
-  , Types.manager
+  , server
+  , database
+  , precision
+  , manager
 
   -- * Parsing results
   , QueryResults(..)
   , parseResultsWith
-  , parseKey
 
   -- * Low-level functions
   , withQueryResponse
   ) where
 import Control.Exception
 import Control.Monad
-import Text.Printf
+import Data.Char
+import Data.List
 
 import Control.Lens
 import Data.Aeson
 import Data.Optional (Optional(..), optional)
-import Data.Text (Text)
 import Data.Vector (Vector)
 import Data.Void
 import qualified Control.Foldl as L
@@ -59,7 +58,35 @@ import Database.InfluxDB.JSON
 import Database.InfluxDB.Types as Types
 import qualified Database.InfluxDB.Format as F
 
+-- $setup
+-- >>> :set -XOverloadedStrings
+-- >>> :set -XRecordWildCards
+-- >>> import Data.Time (UTCTime)
+
+-- | Types that can be converted from an JSON object returned by InfluxDB.
+--
+-- For example the @h2o_feet@ series in
+-- [the official document](https://docs.influxdata.com/influxdb/v1.2/query_language/data_exploration/)
+-- can be encoded as follows:
+--
+-- >>> :{
+-- data H2OFeet = H2OFeet
+--   { time :: UTCTime
+--   , levelDesc :: T.Text
+--   , location :: T.Text
+--   , waterLevel :: Double
+--   }
+-- instance QueryResults H2OFeet where
+--   parseResults prec = parseResultsWith $ \_ _ columns fields -> do
+--     time <- getField "time" columns fields >>= parseUTCTime prec
+--     String levelDesc <- getField "level_description" columns fields
+--     String location <- getField "location" columns fields
+--     FieldFloat waterLevel <-
+--       getField "water_level" columns fields >>= parseQueryField
+--     return H2OFeet {..}
+-- :}
 class QueryResults a where
+  -- | Parse a JSON object as an array of values of expected type.
   parseResults
     :: Precision 'QueryRequest
     -> Value
@@ -149,23 +176,17 @@ instance
         h <- fields V.!? 7
         return (a, b, c, d, e, f, g, h)
 
-parseKey :: Key -> Vector Text -> Array -> A.Parser Key
-parseKey (Key name) columns fields = do
-  case V.elemIndex name columns >>= V.indexM fields of
-    Just (String (F.formatKey F.text -> key)) -> return key
-    _ -> fail $ printf "parseKey: %s not found in columns" $ show name
-
 -- | The full set of parameters for the query API
 data QueryParams = QueryParams
-  { _server :: !Server
-  , _database :: !Database
-  , _precision :: !(Precision 'QueryRequest)
+  { queryServer :: !Server
+  , queryDatabase :: !Database
+  , queryPrecision :: !(Precision 'QueryRequest)
   -- ^ Timestamp precision
   --
   -- InfluxDB uses nanosecond precision if nothing is specified.
-  , _authentication :: !(Maybe Credentials)
+  , queryAuthentication :: !(Maybe Credentials)
   -- ^ No authentication by default
-  , _manager :: !(Either HC.ManagerSettings HC.Manager)
+  , queryManager :: !(Either HC.ManagerSettings HC.Manager)
   -- ^ HTTP connection manager
   }
 
@@ -173,16 +194,16 @@ data QueryParams = QueryParams
 --
 -- Default parameters:
 --
---   ['L.server'] 'localServer'
+--   ['L.server'] 'defaultServer'
 --   ['L.precision'] 'RFC3339'
 --   ['L.authentication'] 'Nothing'
 --   ['L.manager'] @'Left' 'HC.defaultManagerSettings'@
 queryParams :: Database -> QueryParams
-queryParams _database = QueryParams
-  { _server = localServer
-  , _precision = RFC3339
-  , _authentication = Nothing
-  , _manager = Left HC.defaultManagerSettings
+queryParams queryDatabase = QueryParams
+  { queryServer = defaultServer
+  , queryPrecision = RFC3339
+  , queryAuthentication = Nothing
+  , queryManager = Left HC.defaultManagerSettings
   , ..
   }
 
@@ -197,7 +218,7 @@ query params q = withQueryResponse params Nothing q go
       let body = BL.fromChunks chunks
       case eitherDecode' body of
         Left message -> throwIO $ IllformedJSON message body
-        Right val -> case A.parse (parseResults (_precision params)) val of
+        Right val -> case A.parse (parseResults (queryPrecision params)) val of
           A.Success vec -> return vec
           A.Error message ->
             errorQuery request response message
@@ -255,7 +276,7 @@ queryChunked params chunkSize q (L.FoldM step initialize extract) =
               chunk' <- HC.responseBody response
               loop x k' chunk'
             AB.Done leftover val ->
-              case A.parse (parseResults (_precision params)) val of
+              case A.parse (parseResults (queryPrecision params)) val of
                 A.Success vec -> do
                   x' <- step x vec
                   loop x' k0 leftover
@@ -275,19 +296,19 @@ withQueryResponse
   -> (HC.Request -> HC.Response HC.BodyReader -> IO r)
   -> IO r
 withQueryResponse params chunkSize q f = do
-    manager' <- either HC.newManager return $ _manager params
+    manager' <- either HC.newManager return $ queryManager params
     HC.withResponse request manager' (f request)
       `catch` (throwIO . HTTPException)
   where
     request =
-      HC.setQueryString (setPrecision (_precision params) queryString) $
+      HC.setQueryString (setPrecision (queryPrecision params) queryString) $
         queryRequest params
     queryString = addChunkedParam
       [ ("q", Just $ F.fromQuery q)
       , ("db", Just db)
       ]
       where
-        !db = TE.encodeUtf8 $ databaseName $ _database params
+        !db = TE.encodeUtf8 $ databaseName $ queryDatabase params
     addChunkedParam ps = case chunkSize of
       Nothing -> ps
       Just size ->
@@ -306,7 +327,7 @@ queryRequest QueryParams {..} = HC.defaultRequest
   , HC.path = "/query"
   }
   where
-    Server {..} = _server
+    Server {..} = queryServer
 
 errorQuery :: HC.Request -> HC.Response body -> String -> IO a
 errorQuery request response message = do
@@ -318,51 +339,50 @@ errorQuery request response message = do
   fail $ "BUG: " ++ message ++ " in Database.InfluxDB.Query.query - "
     ++ show request
 
-makeLensesWith (lensRules & generateSignatures .~ False) ''QueryParams
-
-server :: Lens' QueryParams Server
+makeLensesWith
+  ( lensRules
+    & lensField .~ mappingNamer
+      (\name -> case stripPrefix "query" name of
+        Just (c:cs) -> ['_':toLower c:cs]
+        _ -> [])
+    )
+  ''QueryParams
 
 -- |
 -- >>> let p = queryParams "foo"
 -- >>> p ^. server.host
 -- "localhost"
 instance HasServer QueryParams where
-  server = Database.InfluxDB.Query.server
-
-database :: Lens' QueryParams Database
+  server = _server
 
 -- |
 -- >>> let p = queryParams "foo"
 -- >>> p ^. database
 -- "foo"
 instance HasDatabase QueryParams where
-  database = Database.InfluxDB.Query.database
-
-precision :: Lens' QueryParams (Precision 'QueryRequest)
+  database = _database
 
 -- | Returning JSON responses contain timestamps in the specified
 -- precision/format.
 --
 -- >>> let p = queryParams "foo"
 -- >>> p ^. precision
--- Nanosecond
+-- RFC3339
 instance HasPrecision 'QueryRequest QueryParams where
-  precision = Database.InfluxDB.Query.precision
-
-manager :: Lens' QueryParams (Either HC.ManagerSettings HC.Manager)
+  precision = _precision
 
 -- |
--- >>> let p = queryParams "foo"
--- >>> p & manager .~ Left HC.defaultManagerSettings
+-- >>> let p = queryParams "foo" & manager .~ Left HC.defaultManagerSettings
 instance HasManager QueryParams where
-  manager = Database.InfluxDB.Query.manager
+  manager = _manager
 
 -- | Authentication info for the query
 --
 -- >>> let p = queryParams "foo"
 -- >>> p ^. authentication
 -- Nothing
-authentication :: Lens' QueryParams (Maybe Credentials)
-
+-- >>> let p' = p & authentication ?~ credentials "john" "passw0rd"
+-- >>> p' ^. authentication.traverse.user
+-- "john"
 instance HasCredentials QueryParams where
-  authentication = Database.InfluxDB.Query.authentication
+  authentication = _authentication

--- a/src/Database/InfluxDB/Write.hs
+++ b/src/Database/InfluxDB/Write.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
@@ -6,8 +7,14 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE ViewPatterns #-}
+#if __GLASGOW_HASKELL__ >= 800
+{-# OPTIONS_GHC -Wno-missing-signatures #-}
+#else
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
+#endif
 module Database.InfluxDB.Write
   ( -- * Writers
+    -- $intro
     write
   , writeBatch
   , writeByteString
@@ -38,20 +45,36 @@ import Database.InfluxDB.Line
 import Database.InfluxDB.Types as Types
 import Database.InfluxDB.JSON
 
+-- $setup
+-- >>> :set -XOverloadedStrings
+-- >>> import qualified Data.Map as Map
+-- >>> import Data.Time
+-- >>> import Database.InfluxDB
+-- >>> manage (queryParams "test-db") "CREATE DATABASE \"test-db\""
+
+{- $intro
+The code snippets in this module assume the following imports.
+
+@
+import qualified Data.Map as Map
+import Data.Time
+@
+-}
+
 -- | The full set of parameters for the HTTP writer.
 data WriteParams = WriteParams
-  { _server :: !Server
-  , _database :: !Database
+  { writeServer :: !Server
+  , writeDatabase :: !Database
   -- ^ Database to be written
-  , _retentionPolicy :: !(Maybe Key)
+  , writeRetentionPolicy :: !(Maybe Key)
   -- ^ 'Nothing' means the default retention policy for the database.
-  , _precision :: !(Precision 'WriteRequest)
+  , writePrecision :: !(Precision 'WriteRequest)
   -- ^ Timestamp precision
   --
   -- In the HTTP API, timestamps are scaled by the given precision.
-  , _authentication  :: !(Maybe Credentials)
+  , writeAuthentication  :: !(Maybe Credentials)
   -- ^ No authentication by default
-  , _manager :: !(Either HC.ManagerSettings HC.Manager)
+  , writeManager :: !(Either HC.ManagerSettings HC.Manager)
   -- ^ HTTP connection manager
   }
 
@@ -59,44 +82,55 @@ data WriteParams = WriteParams
 --
 -- Default parameters:
 --
---   ['L.server'] 'localServer'
+--   ['L.server'] 'defaultServer'
 --   ['L.precision'] 'Nanosecond'
 --   ['retentionPolicy'] 'Nothing'
 --   ['L.manager'] @'Left' 'HC.defaultManagerSettings'@
 writeParams :: Database -> WriteParams
-writeParams _database = WriteParams
-  { _server = localServer
-  , _precision = Nanosecond
-  , _retentionPolicy = Nothing
-  , _authentication = Nothing
-  , _manager = Left HC.defaultManagerSettings
+writeParams writeDatabase = WriteParams
+  { writeServer = defaultServer
+  , writePrecision = Nanosecond
+  , writeRetentionPolicy = Nothing
+  , writeAuthentication = Nothing
+  , writeManager = Left HC.defaultManagerSettings
   , ..
   }
 
--- | Write a 'Line'
+-- | Write a 'Line'.
+--
+-- >>> let p = writeParams "test-db"
+-- >>> write p $ Line "room_temp" Map.empty (Map.fromList [("temp", FieldFloat 25.0)]) (Nothing :: Maybe UTCTime)
 write
   :: Timestamp time
   => WriteParams
   -> Line time
   -> IO ()
-write p@WriteParams {_precision} =
-  writeByteString p . encodeLine (scaleTo _precision)
+write p@WriteParams {writePrecision} =
+  writeByteString p . encodeLine (scaleTo writePrecision)
 
--- | Write 'Line's in a batch
+-- | Write multiple 'Line's in a batch.
 --
--- This is more efficient than 'write'.
+-- This is more efficient than calling 'write' multiple times.
+--
+-- >>> let p = writeParams "test-db"
+-- >>> :{
+-- writeBatch p
+--   [ Line "temp" (Map.singleton "city" "tokyo") (Map.fromList [("temp", FieldFloat 25.0)]) (Nothing :: Maybe UTCTime)
+--   , Line "temp" (Map.singleton "city" "osaka") (Map.fromList [("temp", FieldFloat 25.2)]) (Nothing :: Maybe UTCTime)
+--   ]
+-- :}
 writeBatch
   :: (Timestamp time, Foldable f)
   => WriteParams
   -> f (Line time)
   -> IO ()
-writeBatch p@WriteParams {_precision} =
-  writeByteString p . encodeLines (scaleTo _precision)
+writeBatch p@WriteParams {writePrecision} =
+  writeByteString p . encodeLines (scaleTo writePrecision)
 
 -- | Write a raw 'BL.ByteString'
 writeByteString :: WriteParams -> BL.ByteString -> IO ()
 writeByteString params payload = do
-  manager' <- either HC.newManager return $ _manager params
+  manager' <- either HC.newManager return $ writeManager params
   response <- HC.httpLbs request manager' `catch` (throwIO . HTTPException)
   let body = HC.responseBody response
       status = HC.responseStatus response
@@ -112,7 +146,8 @@ writeByteString params payload = do
         throwIO $ IllformedJSON message body
       Right val -> case A.parse parseErrorObject val of
         A.Success _ ->
-          fail $ "BUG: impossible code path in Database.InfluxDB.Write.writeByteString"
+          fail $ "BUG: impossible code path in "
+            ++ "Database.InfluxDB.Write.writeByteString"
         A.Error message -> do
           when (HT.statusIsServerError status) $
             throwIO $ ServerError message
@@ -136,74 +171,77 @@ writeRequest WriteParams {..} =
     , HC.path = "/write"
     }
   where
-    Server {..} = _server
+    Server {..} = writeServer
     qs = concat
-      [ [("db", Just $ TE.encodeUtf8 $ databaseName _database)]
+      [ [("db", Just $ TE.encodeUtf8 $ databaseName writeDatabase)]
       , fromMaybe [] $ do
-        Key name <- _retentionPolicy
+        Key name <- writeRetentionPolicy
         return [("rp", Just (TE.encodeUtf8 name))]
       , fromMaybe [] $ do
-        Credentials { _user = u, _password = p } <- _authentication
+        Credentials { _user = u, _password = p } <- writeAuthentication
         return
           [ ("u", Just (TE.encodeUtf8 u))
           , ("p", Just (TE.encodeUtf8 p))
           ]
       ]
 
-makeLensesWith (lensRules & generateSignatures .~ False) ''WriteParams
-
-server :: Lens' WriteParams Server
+makeLensesWith
+  ( lensRules
+    & generateSignatures .~ False
+    & lensField .~ lookingupNamer
+      [ ("writeServer", "_server")
+      , ("writeDatabase", "_database")
+      , ("writeRetentionPolicy", "retentionPolicy")
+      , ("writePrecision", "_precision")
+      , ("writeManager", "_manager")
+      , ("writeAuthentication", "_authentication")
+      ]
+    )
+  ''WriteParams
 
 -- |
 -- >>> let p = writeParams "foo"
 -- >>> p ^. server.host
 -- "localhost"
 instance HasServer WriteParams where
-  server = Database.InfluxDB.Write.server
-
-database :: Lens' WriteParams Database
+  server = _server
 
 -- |
 -- >>> let p = writeParams "foo"
 -- >>> p ^. database
 -- "foo"
 instance HasDatabase WriteParams where
-  database = Database.InfluxDB.Write.database
+  database = _database
 
 -- | Target retention policy for the write.
 --
 -- InfluxDB writes to the @default@ retention policy if this parameter is set
 -- to 'Nothing'.
 --
--- >>> let p = writeParams "foo"
--- >>> let p' = p & retentionPolicy .~ Just "two_hours"
--- >>> p' ^. retentionPolicy
+-- >>> let p = writeParams "foo" & retentionPolicy .~ Just "two_hours"
+-- >>> p ^. retentionPolicy
 -- Just "two_hours"
 retentionPolicy :: Lens' WriteParams (Maybe Key)
-
-precision :: Lens' WriteParams (Precision 'WriteRequest)
 
 -- |
 -- >>> let p = writeParams "foo"
 -- >>> p ^. precision
 -- Nanosecond
 instance HasPrecision 'WriteRequest WriteParams where
-  precision = Database.InfluxDB.Write.precision
-
-manager :: Lens' WriteParams (Either HC.ManagerSettings HC.Manager)
+  precision = _precision
 
 -- |
--- >>> let p = writeParams "foo"
--- >>> p & manager .~ Left HC.defaultManagerSettings
+-- >>> let p = writeParams "foo" & manager .~ Left HC.defaultManagerSettings
 instance HasManager WriteParams where
-  manager = Database.InfluxDB.Write.manager
+  manager = _manager
 
 -- | Authentication info for the write
 --
 -- >>> let p = writeParams "foo"
 -- >>> p ^. authentication
 -- Nothing
-authentication :: Lens' WriteParams (Maybe Credentials)
-
+-- >>> let p' = p & authentication ?~ credentials "john" "passw0rd"
+-- >>> p' ^. authentication . traverse . user
+-- "john"
 instance HasCredentials WriteParams where
-  authentication = Database.InfluxDB.Write.authentication
+  authentication = _authentication


### PR DESCRIPTION
This PR extends Haddock comments with some doctests. Also it cleans up the API and therefore introduces a lot of breaking changes.

I was using cabal-doctest while working on this branch but retracted it because it didn't work on GHC < 8.0.