### PR TITLE
Switch from lens to microlens

### DIFF
--- a/influxdb.cabal
+++ b/influxdb.cabal
@@ -69,10 +69,12 @@ library
     , foldl < 1.4
     , http-client >= 0.5 && < 0.6
     , http-types >= 0.8.6 && < 0.10
-    , lens >= 4.9 && < 4.16
+    , microlens >= 0.4.7 && < 0.5
+    , microlens-th >= 0.4.1 && < 0.5
     , network >= 2.6 && < 2.7
     , optional-args >= 1.0 && < 1.1
     , scientific >= 0.3.3 && < 0.4
+    , template-haskell >= 2.11.1 && <2.13
     , text < 1.3
     , time >= 1.5 && < 1.9
     , unordered-containers < 0.3

--- a/src/Database/InfluxDB/Line.hs
+++ b/src/Database/InfluxDB/Line.hs
@@ -24,7 +24,8 @@ import Data.List (intersperse)
 import Data.Int (Int64)
 import Data.Monoid
 
-import Control.Lens
+import Lens.Micro
+import Lens.Micro.TH
 import Data.Map (Map)
 import Data.Text (Text)
 import qualified Data.ByteString.Builder as B

--- a/src/Database/InfluxDB/Manage.hs
+++ b/src/Database/InfluxDB/Manage.hs
@@ -37,7 +37,8 @@ import Control.Applicative
 import Control.Exception
 import Control.Monad
 
-import Control.Lens
+import Lens.Micro
+import Lens.Micro.TH
 import Data.Aeson
 import Data.Scientific (toBoundedInteger)
 import Data.Text (Text)
@@ -148,14 +149,13 @@ instance QueryResults ShowSeries where
     return $ ShowSeries $ F.formatKey F.text name
 
 makeLensesWith
-  ( lensRules
+  ( lensRulesFor
+    [ ("showQueryQid", "qid")
+    , ("showQueryText", "queryText")
+    , ("showQueryDatabase", "_database")
+    , ("showQueryDuration", "duration")
+    ]
     & generateSignatures .~ False
-    & lensField .~ lookingupNamer
-      [ ("showQueryQid", "qid")
-      , ("showQueryText", "queryText")
-      , ("showQueryDatabase", "_database")
-      , ("showQueryDuration", "duration")
-      ]
   ) ''ShowQuery
 
 -- | Query ID

--- a/src/Database/InfluxDB/Ping.hs
+++ b/src/Database/InfluxDB/Ping.hs
@@ -25,7 +25,8 @@ module Database.InfluxDB.Ping
   ) where
 import Control.Exception
 
-import Control.Lens
+import Lens.Micro
+import Lens.Micro.TH
 import Data.Time.Clock (NominalDiffTime)
 import System.Clock
 import qualified Data.ByteString as BS
@@ -59,13 +60,12 @@ pingParams = PingParams
   }
 
 makeLensesWith
-  ( lensRules
+  ( lensRulesFor
+    [ ("pingServer", "_server")
+    , ("pingManager", "_manager")
+    , ("pingTimeout", "timeout")
+    ]
     & generateSignatures .~ False
-    & lensField .~ lookingupNamer
-      [ ("pingServer", "_server")
-      , ("pingManager", "_manager")
-      , ("pingTimeout", "timeout")
-      ]
     )
   ''PingParams
 

--- a/src/Database/InfluxDB/Query.hs
+++ b/src/Database/InfluxDB/Query.hs
@@ -36,7 +36,9 @@ import Control.Monad
 import Data.Char
 import Data.List
 
-import Control.Lens
+import Lens.Micro
+import Lens.Micro.TH
+import Language.Haskell.TH
 import Data.Aeson
 import Data.Optional (Optional(..), optional)
 import Data.Vector (Vector)
@@ -341,10 +343,9 @@ errorQuery request response message = do
 
 makeLensesWith
   ( lensRules
-    & lensField .~ mappingNamer
-      (\name -> case stripPrefix "query" name of
-        Just (c:cs) -> ['_':toLower c:cs]
-        _ -> [])
+    & lensField .~ (\_ _ name -> case stripPrefix "query" (nameBase name) of
+      Just (c:cs) -> [TopName (mkName ('_':toLower c:cs))]
+      _ -> [])
     )
   ''QueryParams
 

--- a/src/Database/InfluxDB/Types.hs
+++ b/src/Database/InfluxDB/Types.hs
@@ -18,7 +18,8 @@ import Data.String
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 
-import Control.Lens
+import Lens.Micro
+import Lens.Micro.TH
 import Data.Text (Text)
 import Data.Time.Clock
 import Data.Time.Clock.POSIX

--- a/src/Database/InfluxDB/Write.hs
+++ b/src/Database/InfluxDB/Write.hs
@@ -32,7 +32,8 @@ import Control.Exception
 import Control.Monad
 import Data.Maybe
 
-import Control.Lens
+import Lens.Micro
+import Lens.Micro.TH
 import qualified Data.Aeson as A
 import qualified Data.Aeson.Types as A
 import qualified Data.ByteString.Char8 as B8
@@ -186,16 +187,15 @@ writeRequest WriteParams {..} =
       ]
 
 makeLensesWith
-  ( lensRules
+  ( lensRulesFor
+    [ ("writeServer", "_server")
+    , ("writeDatabase", "_database")
+    , ("writeRetentionPolicy", "retentionPolicy")
+    , ("writePrecision", "_precision")
+    , ("writeManager", "_manager")
+    , ("writeAuthentication", "_authentication")
+    ]
     & generateSignatures .~ False
-    & lensField .~ lookingupNamer
-      [ ("writeServer", "_server")
-      , ("writeDatabase", "_database")
-      , ("writeRetentionPolicy", "retentionPolicy")
-      , ("writePrecision", "_precision")
-      , ("writeManager", "_manager")
-      , ("writeAuthentication", "_authentication")
-      ]
     )
   ''WriteParams
 

--- a/src/Database/InfluxDB/Write/UDP.hs
+++ b/src/Database/InfluxDB/Write/UDP.hs
@@ -17,7 +17,8 @@ module Database.InfluxDB.Write.UDP
   , Types.precision
   ) where
 
-import Control.Lens
+import Lens.Micro
+import Lens.Micro.TH
 import Network.Socket (SockAddr, Socket)
 import Network.Socket.ByteString (sendManyTo)
 import qualified Data.ByteString.Lazy as BL


### PR DESCRIPTION
This switches from [lens](https://hackage.haskell.org/package/lens) to [microlens](https://hackage.haskell.org/package/microlens) (and [microlens-th](https://hackage.haskell.org/package/microlens-th)). The main gain here is compilation speed. Most of lens's dependencies are already brought in, but microlens still saves a few.

``` diff
3d2
< adjunctions 4.3
31d29
< free 4.12.4
40,41c38,39
< kan-extensions 5.0.1
< lens 4.15.1
---
> microlens 0.4.7.0
> microlens-th 0.4.1.1
49d46
< parallel 3.2.1.0
51d47
< prelude-extras 0.4.0.3
57d52
< reflection 2.1.2
60d54
< semigroupoids 5.1
```