### PR TITLE
Improve error handling

### DIFF
--- a/examples/random-points.hs
+++ b/examples/random-points.hs
@@ -76,7 +76,7 @@ data Row = Row
   } deriving Show
 
 instance QueryResults Row where
-  parseResults prec = parseResultsWith $ \_ _ columns fields -> do
+  parseMeasurement prec _ _ columns fields = do
     rowTime <- getField "time" columns fields >>= parsePOSIXTime prec
     String name <- getField "value" columns fields
     rowValue <- case name of

--- a/examples/random-points.hs
+++ b/examples/random-points.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE ViewPatterns #-}
 import Data.Foldable

--- a/influxdb.cabal
+++ b/influxdb.cabal
@@ -115,10 +115,12 @@ test-suite regressions
       base
     , containers
     , influxdb
+    , lens
     , tasty
     , tasty-hunit
     , time
     , raw-strings-qq >= 1.1 && < 1.2
+    , vector
   ghc-options: -Wall -threaded
   hs-source-dirs: tests
   default-language: Haskell2010

--- a/src/Database/InfluxDB.hs
+++ b/src/Database/InfluxDB.hs
@@ -49,7 +49,7 @@ module Database.InfluxDB
 
   -- ** Parsing results
   , QueryResults(..)
-  , Decoder(..)
+  , Decoder
   , lenientDecoder
   , strictDecoder
   , getField

--- a/src/Database/InfluxDB.hs
+++ b/src/Database/InfluxDB.hs
@@ -59,7 +59,6 @@ module Database.InfluxDB
   , parseJSON
   , parseUTCTime
   , parsePOSIXTime
-  , parseQueryField
 
   -- *** Re-exports from tagged
   , Tagged(..)

--- a/src/Database/InfluxDB.hs
+++ b/src/Database/InfluxDB.hs
@@ -49,8 +49,6 @@ module Database.InfluxDB
 
   -- ** Parsing results
   , QueryResults(..)
-  , parseResultsWith
-  , parseResultsWithDecoder
   , Decoder(..)
   , lenientDecoder
   , strictDecoder

--- a/src/Database/InfluxDB.hs
+++ b/src/Database/InfluxDB.hs
@@ -45,6 +45,7 @@ module Database.InfluxDB
   , QueryParams
   , queryParams
   , authentication
+  , decoder
 
   -- ** Parsing results
   , QueryResults(..)
@@ -200,7 +201,7 @@ data CPUUsage = CPUUsage
   , cpuIdle, cpuSystem, cpuUser :: Double
   } deriving Show
 instance QueryResults CPUUsage where
-  parseResults prec = parseResultsWithDecoder strictDecoder $ \_ _ columns fields -> do
+  parseMeasurement prec _name _tags columns fields = do
     time <- getField "time" columns fields >>= parseUTCTime prec
     cpuIdle <- getField "idle" columns fields >>= parseJSON
     cpuSystem <- getField "system" columns fields >>= parseJSON

--- a/src/Database/InfluxDB/JSON.hs
+++ b/src/Database/InfluxDB/JSON.hs
@@ -27,7 +27,6 @@ module Database.InfluxDB.JSON
   , parseUTCTime
   , parsePOSIXTime
   , parseRFC3339
-  , parseQueryField
   -- ** Utility functions
   , parseResultsObject
   , parseSeriesObject
@@ -241,20 +240,3 @@ parseRFC3339 val = A.withText err
     fmt, err :: String
     fmt = "%FT%X%QZ"
     err = "RFC3339-formatted timestamp"
-
--- | Parse a 'QueryField'.
-parseQueryField :: A.Value -> A.Parser QueryField
-parseQueryField val = case val of
-  A.Number sci ->
-    return $! either FieldFloat FieldInt $ Sci.floatingOrInteger sci
-  A.String txt ->
-    return $! FieldString txt
-  A.Bool b ->
-    return $! FieldBool b
-  A.Null ->
-    return FieldNull
-  _ -> fail $ "parseQueryField: expected a flat data structure, but got "
-    ++ show val
-{-# DEPRECATED parseQueryField
-  "This function parses numbers in a misleading way. Use 'parseJSON' instead."
-  #-}

--- a/src/Database/InfluxDB/JSON.hs
+++ b/src/Database/InfluxDB/JSON.hs
@@ -54,7 +54,7 @@ import qualified Data.Vector as V
 
 import Database.InfluxDB.Types
 
--- | Parse a JSON response with the 'lenientDecoder'. This can be useful to
+-- | Parse a JSON response with the 'strictDecoder'. This can be useful to
 -- implement the 'Database.InfluxDB.Query.parseResults' method.
 parseResultsWith
   :: (Maybe Text -> HashMap Text Text -> Vector Text -> Array -> A.Parser a)
@@ -68,7 +68,7 @@ parseResultsWith
   -- to construct a value.
   -> Value
   -> A.Parser (Vector a)
-parseResultsWith = parseResultsWithDecoder lenientDecoder
+parseResultsWith = parseResultsWithDecoder strictDecoder
 
 -- | Parse a JSON response with the specified decoder settings.
 parseResultsWithDecoder

--- a/tests/regressions.hs
+++ b/tests/regressions.hs
@@ -1,34 +1,79 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
-import Data.Time.Clock (UTCTime)
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+import Control.Exception (bracket_, try)
+
+import Control.Lens
+import Data.Time
 import Test.Tasty
 import Test.Tasty.HUnit
-import Text.RawString.QQ (r)
 import qualified Data.Map as M
+import qualified Data.Map.Strict as Map
+import qualified Data.Vector as V
+import qualified Text.RawString.QQ as Raw (r)
 
 import Database.InfluxDB
 import Database.InfluxDB.Line
 import qualified Database.InfluxDB.Format as F
 
 main :: IO ()
-main = defaultMain tests
-
-tests :: TestTree
-tests = testGroup "regression tests"
-  [ issue75
+main = defaultMain $ testGroup "regression tests"
+  [ testCase "issue #64" case_issue64
+  , testCase "issue #66" case_issue66
+  , testCaseSteps "issue #75" case_issue75
   ]
 
--- https://github.com/maoe/influxdb-haskell/issues/75
+-- https://github.com/maoe/influxdb-haskell/issues/64
+case_issue64 :: Assertion
+case_issue64 = withDatabase dbName $ do
+  write wp $ Line "count" Map.empty
+    (Map.fromList [("value", FieldInt 1)])
+    (Nothing :: Maybe UTCTime)
+  r <- try $ query qp "SELECT value FROM count"
+  case r of
+    Left err -> case err of
+      UnexpectedResponse message _ _ ->
+        message @?=
+          "BUG: parsing Int failed, expected Number, but encountered String in Database.InfluxDB.Query.query"
+      _ ->
+        assertFailure $ got ++ show err
+    Right (v :: (V.Vector (Tagged "time" Int, Tagged "value" Int))) ->
+      -- NOTE: The time columns should be UTCTime, Text, or String
+      assertFailure $ got ++ "no errors: " ++ show v
+  where
+    dbName = "case_issue64"
+    qp = queryParams dbName & precision .~ RFC3339
+    wp = writeParams dbName
+    got = "expeted an UnexpectedResponse but got "
 
-issue75 :: TestTree
-issue75 = testCaseSteps "issue #75" $ \step -> do
+-- https://github.com/maoe/influxdb-haskell/issues/66
+case_issue66 :: Assertion
+case_issue66 = do
+  r <- try $ query (queryParams "_internal") "SELECT time FROM dummy"
+  case r of
+    Left err -> case err of
+      UnexpectedResponse message _ _ ->
+        message @?=
+          "BUG: at least 1 non-time field must be queried in Database.InfluxDB.Query.query"
+      _ ->
+        assertFailure $ got ++ show err
+    Right (v :: V.Vector (Tagged "time" Int)) ->
+      assertFailure $ got ++ "no errors: " ++ show v
+  where
+    got = "expected an UnexpectedResponse but got "
+
+-- https://github.com/maoe/influxdb-haskell/issues/75
+case_issue75 :: (String -> IO ()) -> Assertion
+case_issue75 step = do
   step "Checking encoded value"
-  let string = [r|bl\"a|]
+  let string = [Raw.r|bl\"a|]
   let encoded = encodeLine (scaleTo Nanosecond)
         $ Line "testing" mempty
           (M.singleton "test" $ FieldString string)
           (Nothing :: Maybe UTCTime)
-  encoded @?= [r|testing test="bl\\\"a"|]
+  encoded @?= [Raw.r|testing test="bl\\\"a"|]
 
   step "Preparing a test database"
   let db = "issue75"
@@ -39,3 +84,11 @@ issue75 = testCaseSteps "issue #75" $ \step -> do
   step "Checking server response"
   let wp = writeParams db
   writeByteString wp encoded
+
+withDatabase :: Database -> IO a -> IO a
+withDatabase dbName f = bracket_
+  (manage q (formatQuery ("CREATE DATABASE "%F.database) dbName))
+  (manage q (formatQuery ("DROP DATABASE "%F.database) dbName))
+  f
+  where
+    q = queryParams dbName


### PR DESCRIPTION
This PR reworks the `QueryResults` type class for the sake of more flexible error handling.

Previously `parseResults` used `lenientDecoder` which caused some unintuitive behaviors (#64, #66). `parseResults` is now moved out from `QueryResults` and deprecated. The `parseMeasurement` method is added instead. This is good because now the decision to choose a `Decoder` can be made at runtime by configuring `QueryParams` rather than hardcoding into the `QueryResults` instances.

