### PR TITLE
Handle non-empty results properly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,12 +48,6 @@ jobs:
     - compiler: ghc-8.4.4
       addons: {"apt":{"sources":[{"sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main","key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286"}],"packages":["ghc-8.4.4","cabal-install-3.2"]}}
       os: linux
-    - compiler: ghc-8.2.2
-      addons: {"apt":{"sources":[{"sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main","key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286"}],"packages":["ghc-8.2.2","cabal-install-3.2"]}}
-      os: linux
-    - compiler: ghc-8.0.2
-      addons: {"apt":{"sources":[{"sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main","key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286"}],"packages":["ghc-8.0.2","cabal-install-3.2"]}}
-      os: linux
     - compiler: ghc-head
       addons: {"apt":{"sources":[{"sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main","key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286"}],"packages":["ghc-head","cabal-install-head"]}}
       os: linux
@@ -122,8 +116,8 @@ install:
   - touch cabal.project
   - |
     echo "packages: ." >> cabal.project
-  - if [ $HCNUMVER -ge 80200 ] ; then echo 'package influxdb' >> cabal.project ; fi
-  - "if [ $HCNUMVER -ge 80200 ] ; then echo '  ghc-options: -Werror=missing-methods' >> cabal.project ; fi"
+  - echo 'package influxdb' >> cabal.project
+  - "echo '  ghc-options: -Werror=missing-methods' >> cabal.project"
   - |
   - "for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/-[^-]*$//' | (grep -vE -- '^(influxdb)$' || true) | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local; done"
   - cat cabal.project || true
@@ -149,8 +143,8 @@ script:
   - touch cabal.project
   - |
     echo "packages: ${PKGDIR_influxdb}" >> cabal.project
-  - if [ $HCNUMVER -ge 80200 ] ; then echo 'package influxdb' >> cabal.project ; fi
-  - "if [ $HCNUMVER -ge 80200 ] ; then echo '  ghc-options: -Werror=missing-methods' >> cabal.project ; fi"
+  - echo 'package influxdb' >> cabal.project
+  - "echo '  ghc-options: -Werror=missing-methods' >> cabal.project"
   - |
   - "for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/-[^-]*$//' | (grep -vE -- '^(influxdb)$' || true) | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local; done"
   - cat cabal.project || true

--- a/hie.yaml
+++ b/hie.yaml
@@ -3,10 +3,10 @@ cradle:
     - path: "./src"
       component: "lib:influxdb"
 
-    - path: "./tests"
+    - path: "./tests/doctests.hs"
       component: "influxdb:test:doctests"
 
-    - path: "./tests"
+    - path: "./tests/regressions.hs"
       component: "influxdb:test:regressions"
 
     - path: "./examples/random-points.hs"

--- a/influxdb.cabal
+++ b/influxdb.cabal
@@ -15,8 +15,6 @@ copyright: Copyright (C) 2014-2020 Mitsutoshi Aoe
 category: Database
 build-type: Custom
 tested-with:
-  GHC == 8.0.2
-  GHC == 8.2.2
   GHC == 8.4.4
   GHC == 8.6.5
   GHC == 8.8.3
@@ -75,7 +73,7 @@ library
     ViewPatterns
   ghc-options: -Wall
   build-depends:
-      base >= 4.9 && < 4.15
+      base >= 4.11 && < 4.15
     , aeson >= 0.7 && < 1.6
     , attoparsec < 0.14
     , bytestring >= 0.10 && < 0.11

--- a/src/Database/InfluxDB.hs
+++ b/src/Database/InfluxDB.hs
@@ -52,15 +52,19 @@ module Database.InfluxDB
   , Decoder
   , lenientDecoder
   , strictDecoder
+
+  -- ** Helper types and functions
+  , Ignored
+  , Empty
+  , Tagged(..)
+  , untag
+
   , getField
   , getTag
   , parseJSON
   , parseUTCTime
   , parsePOSIXTime
 
-  -- *** Re-exports from tagged
-  , Tagged(..)
-  , untag
 
   -- * Database management
   , manage

--- a/src/Database/InfluxDB/Manage.hs
+++ b/src/Database/InfluxDB/Manage.hs
@@ -43,7 +43,6 @@ import Data.Aeson
 import Data.Scientific (toBoundedInteger)
 import Data.Text (Text)
 import Data.Time.Clock
-import Data.Void
 import qualified Data.Aeson.Types as A
 import qualified Data.Attoparsec.Combinator as AC
 import qualified Data.Attoparsec.Text as AT
@@ -80,7 +79,7 @@ manage params q = do
             (params ^. decoder)
             (params ^. precision)
       case A.parse parser val of
-        A.Success (_ :: V.Vector Void) -> return ()
+        A.Success (_ :: V.Vector Empty) -> return ()
         A.Error message -> do
           let status = HC.responseStatus response
           when (HT.statusIsServerError status) $

--- a/src/Database/InfluxDB/Manage.hs
+++ b/src/Database/InfluxDB/Manage.hs
@@ -76,7 +76,9 @@ manage params q = do
     Left message ->
       throwIO $ UnexpectedResponse message request body
     Right val -> do
-      let parser = parseQueryResultsWith (params^.decoder) (params^.precision)
+      let parser = parseQueryResultsWith
+            (params ^. decoder)
+            (params ^. precision)
       case A.parse parser val of
         A.Success (_ :: V.Vector Void) -> return ()
         A.Error message -> do

--- a/src/Database/InfluxDB/Query.hs
+++ b/src/Database/InfluxDB/Query.hs
@@ -99,13 +99,6 @@ import qualified Database.InfluxDB.Format as F
 --     return H2OFeet {..}
 -- :}
 class QueryResults a where
-  -- | Parse a JSON object as an array of values of expected type.
-  parseResults
-    :: Precision 'QueryRequest
-    -> Value
-    -> A.Parser (Vector a)
-  parseResults = parseQueryResultsWith strictDecoder
-
   -- | Parse a measurement in a JSON object.
   parseMeasurement
     :: Precision 'QueryRequest
@@ -120,8 +113,6 @@ class QueryResults a where
     -- ^ Field values
     -> A.Parser a
 
-{-# DEPRECATED parseResults
-  "Use 'parseQueryResults' or 'parseQueryResultsWith' " #-}
 
 -- | Parse a JSON object as an array of values of expected type.
 parseQueryResults
@@ -441,7 +432,7 @@ queryChunked params chunkSize q (L.FoldM step initialize extract) =
               chunk' <- HC.responseBody response
               loop x k' chunk'
             AB.Done leftover val ->
-              case A.parse (parseResults (queryPrecision params)) val of
+              case A.parse (parseQueryResults (queryPrecision params)) val of
                 A.Success vec -> do
                   x' <- step x vec
                   loop x' k0 leftover

--- a/tests/regressions.hs
+++ b/tests/regressions.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 import Control.Exception (bracket_, try)
-import Data.Void
 
 import Control.Lens
 import Data.Time
@@ -95,13 +94,15 @@ case_issue79 step = withDatabase db $ do
   step "Querying an empty series with two fields expected"
   _ <- query @(Tagged "time" UTCTime, Tagged "value" Int) q "SELECT * FROM foo"
   step "Querying an empty series with the results ignored"
-  _ <- query @Void q "SELECT * FROM foo"
+  _ <- query @Ignored q "SELECT * FROM foo"
+  step "Querying an empty series expecting an empty result"
+  _ <- query @Empty q "SELECT * FROM foo"
   step "Writing a data point"
   write w $ Line "foo" mempty (Map.fromList [("value", FieldInt 42)]) (Nothing :: Maybe UTCTime)
   step "Querying a non-empty series with two fields expected"
   _ <- query @(Tagged "time" UTCTime, Tagged "value" Int) q "SELECT * FROM foo"
   step "Querying a non-empty series with the results ignored"
-  _ <- query @Void q "SELECT * FROM foo"
+  _ <- query @Ignored q "SELECT * FROM foo"
   return ()
   where
     db = "case_issue79"


### PR DESCRIPTION
This PR introduces the new types `Ignored` and `Empty` deprecating the `QueryResults` instance for `Void` to fix #79.