### PR TITLE
Mitigate InfluxDB compatibility problems.

### DIFF
--- a/src/Database/InfluxDB/JSON.hs
+++ b/src/Database/InfluxDB/JSON.hs
@@ -200,8 +200,12 @@ parseSeriesBody = A.withObject "series" $ \obj -> do
   return (name, tags, columns, values)
 
 -- | Parse the common JSON structure used in failure response.
+-- >>> A.parse parseErrorObject $ fromJust $ decode "{ \"error\": \"custom error\" }"
+-- Success "custom error"
+-- >>> A.parse parseErrorObject $ fromJust $ decode "{ \"message\": \"custom error\" }"
+-- Success "custom error"
 parseErrorObject :: A.Value -> A.Parser String
-parseErrorObject = A.withObject "error" $ \obj -> obj .: "error"
+parseErrorObject = A.withObject "error" $ \obj -> obj .: "error" <|> obj .: "message"
 
 -- | Parse either a POSIX timestamp or RFC3339 formatted timestamp as 'UTCTime'.
 parseUTCTime :: Precision ty -> A.Value -> A.Parser UTCTime


### PR DESCRIPTION
Unfortunately the v1 compatibility mode of v2 doesn't work as expected in case of error messages. See e.g. https://github.com/influxdata/influxdb/issues/21173

While InfluxDB v1 always shows a `error` element int the response (see https://docs.influxdata.com/influxdb/v1.3/tools/api/), v2 also emits error messages without an `error` element (see https://docs.influxdata.com/influxdb/v2.7/api/v1-compatibility/).

E.g. v2 could return something like `{"code":"unprocessable entity","message":"failure writing points to database: partial write: points beyond retention policy dropped=1"}` - which currently leads to a `ClientError` exception just showing the message that the `error` key isn't present and the requested URL (which is pretty useless since the original error message is swallowed).

Therefore a small change to provide a workaround for this pretty ugly situation 😅 

And for sure we all know that this is a problem of the InfluxDB - but maybe you would like to introduce this pretty small change to provide a workaround; if not, please feel free to just close this PR. 

And independently thanks for providing this library ❤️