### PR TITLE
Support ghc-9.4.

### DIFF
--- a/influxdb.cabal
+++ b/influxdb.cabal
@@ -11,7 +11,7 @@ license: BSD3
 license-file: LICENSE
 author: Mitsutoshi Aoe
 maintainer: Mitsutoshi Aoe <me@maoe.name>
-copyright: Copyright (C) 2014-2021 Mitsutoshi Aoe
+copyright: Copyright (C) 2014-2023 Mitsutoshi Aoe
 category: Database
 build-type: Custom
 tested-with:
@@ -20,6 +20,8 @@ tested-with:
   GHC == 8.8.4
   GHC == 8.10.4
   GHC == 9.0.1
+  GHC == 9.2.8
+  GHC == 9.4.5
 
 extra-source-files:
   README.md
@@ -74,8 +76,8 @@ library
     ViewPatterns
   ghc-options: -Wall
   build-depends:
-      base >= 4.11 && < 4.17
-    , aeson >= 0.7 && < 2.1
+      base >= 4.11 && < 4.18
+    , aeson >= 0.7 && < 2.2
     , attoparsec < 0.15
     , bytestring >= 0.10 && < 0.12
     , clock >= 0.7 && < 0.9
@@ -91,7 +93,7 @@ library
     , text < 2.1
     , time >= 1.5 && < 1.14
     , unordered-containers < 0.3
-    , vector >= 0.10 && < 0.13
+    , vector >= 0.10 && < 0.14
   hs-source-dirs: src
   default-language: Haskell2010
 


### PR DESCRIPTION
Also helps https://github.com/commercialhaskell/stackage/issues/6905 and enables `influxdb-haskell` to get back into the stackage nightly build.