### PR TITLE
Revitalize CI

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -233,7 +233,7 @@ jobs:
           ${CABAL} -vnormal check
       - name: haddock
         run: |
-          $CABAL v2-haddock $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then $CABAL v2-haddock --disable-documentation --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all ; fi
       - name: unconstrained build
         run: |
           rm -f cabal.project.local

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -63,6 +63,11 @@ jobs:
             compilerVersion: 8.6.5
             setup-method: hvr-ppa
             allow-failure: false
+          - compiler: ghc-8.4.4
+            compilerKind: ghc
+            compilerVersion: 8.4.4
+            setup-method: hvr-ppa
+            allow-failure: false
       fail-fast: false
     steps:
       - name: apt
@@ -228,7 +233,7 @@ jobs:
           ${CABAL} -vnormal check
       - name: haddock
         run: |
-          $CABAL v2-haddock --haddock-options=--quickjump $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
+          $CABAL v2-haddock $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
       - name: unconstrained build
         run: |
           rm -f cabal.project.local

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.11.20210222
+# version: 0.16.1
 #
-# REGENDATA ("0.11.20210222",["github","influxdb.cabal"])
+# REGENDATA ("0.16.1",["github","influxdb.cabal"])
 #
 name: Haskell-CI
 on:
@@ -18,61 +18,89 @@ on:
   - pull_request
 jobs:
   linux:
-    name: Haskell-CI - Linux - GHC ${{ matrix.ghc }}
-    runs-on: ubuntu-18.04
+    name: Haskell-CI - Linux - ${{ matrix.compiler }}
+    runs-on: ubuntu-20.04
+    timeout-minutes:
+      60
+    container:
+      image: buildpack-deps:bionic
     continue-on-error: ${{ matrix.allow-failure }}
-    env:
-      INFLUXDB_VERSION: 1.8.4
+    services:
+      influxdb:
+        image: influxdb:1.8.10
+        env:
+          INFLUXDB_REPORTING_DISABLED: true
     strategy:
       matrix:
         include:
-          - ghc: 9.0.1
+          - compiler: ghc-9.0.1
+            compilerKind: ghc
+            compilerVersion: 9.0.1
+            setup-method: hvr-ppa
             allow-failure: false
-          - ghc: 8.10.4
+          - compiler: ghc-8.10.4
+            compilerKind: ghc
+            compilerVersion: 8.10.4
+            setup-method: hvr-ppa
             allow-failure: false
-          - ghc: 8.8.4
+          - compiler: ghc-8.8.4
+            compilerKind: ghc
+            compilerVersion: 8.8.4
+            setup-method: hvr-ppa
             allow-failure: false
-          - ghc: 8.6.5
+          - compiler: ghc-8.6.5
+            compilerKind: ghc
+            compilerVersion: 8.6.5
+            setup-method: hvr-ppa
             allow-failure: false
-          - ghc: 8.4.4
+          - compiler: ghc-8.4.4
+            compilerKind: ghc
+            compilerVersion: 8.4.4
+            setup-method: hvr-ppa
             allow-failure: false
       fail-fast: false
     steps:
       - name: apt
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common
-          sudo apt-add-repository -y 'ppa:hvr/ghc'
-          sudo apt-get update
-          sudo apt-get install -y ghc-$GHC_VERSION cabal-install-3.4
+          apt-get update
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git socat software-properties-common libtinfo5
+          apt-add-repository -y 'ppa:hvr/ghc'
+          apt-get update
+          apt-get install -y "$HCNAME"
+          mkdir -p "$HOME/.ghcup/bin"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
+          chmod a+x "$HOME/.ghcup/bin/ghcup"
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
         env:
-          GHC_VERSION: ${{ matrix.ghc }}
+          HCKIND: ${{ matrix.compilerKind }}
+          HCNAME: ${{ matrix.compiler }}
+          HCVER: ${{ matrix.compilerVersion }}
+      - name: influxdb forward
+        run: |
+          socat TCP-LISTEN:8086,fork TCP:influxdb:8086 &
       - name: Set PATH and environment variables
         run: |
           echo "$HOME/.cabal/bin" >> $GITHUB_PATH
-          echo "LANG=C.UTF-8" >> $GITHUB_ENV
-          echo "CABAL_DIR=$HOME/.cabal" >> $GITHUB_ENV
-          echo "CABAL_CONFIG=$HOME/.cabal/config" >> $GITHUB_ENV
-          HC=/opt/ghc/$GHC_VERSION/bin/ghc
-          echo "HC=$HC" >> $GITHUB_ENV
-          echo "HCPKG=/opt/ghc/$GHC_VERSION/bin/ghc-pkg" >> $GITHUB_ENV
-          echo "HADDOCK=/opt/ghc/$GHC_VERSION/bin/haddock" >> $GITHUB_ENV
-          echo "CABAL=/opt/cabal/3.4/bin/cabal -vnormal+nowrap" >> $GITHUB_ENV
+          echo "LANG=C.UTF-8" >> "$GITHUB_ENV"
+          echo "CABAL_DIR=$HOME/.cabal" >> "$GITHUB_ENV"
+          echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
+          HCDIR=/opt/$HCKIND/$HCVER
+          HC=$HCDIR/bin/$HCKIND
+          echo "HC=$HC" >> "$GITHUB_ENV"
+          echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
+          echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
-          echo "HCNUMVER=$HCNUMVER" >> $GITHUB_ENV
-          echo "ARG_TESTS=--enable-tests" >> $GITHUB_ENV
-          echo "ARG_BENCH=--enable-benchmarks" >> $GITHUB_ENV
-          echo "HEADHACKAGE=false" >> $GITHUB_ENV
-          echo "ARG_COMPILER=--ghc --with-compiler=$HC" >> $GITHUB_ENV
-          echo "GHCJSARITH=0" >> $GITHUB_ENV
+          echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
+          echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
+          echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
+          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
+          echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
-          GHC_VERSION: ${{ matrix.ghc }}
-      - name: Set up InfluxDB
-        run: |
-          wget -q https://dl.influxdata.com/influxdb/releases/influxdb_${INFLUXDB_VERSION}_amd64.deb
-          dpkg -x influxdb_${INFLUXDB_VERSION}_amd64.deb influxdb
-          ./influxdb/usr/bin/influxd config
-          ./influxdb/usr/bin/influxd &
+          HCKIND: ${{ matrix.compilerKind }}
+          HCNAME: ${{ matrix.compiler }}
+          HCVER: ${{ matrix.compilerVersion }}
       - name: env
         run: |
           env
@@ -95,6 +123,10 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          cat >> $CABAL_CONFIG <<EOF
+          program-default-options
+            ghc-options: $GHCJOBS +RTS -M3G -RTS
+          EOF
           cat $CABAL_CONFIG
       - name: versions
         run: |
@@ -107,14 +139,14 @@ jobs:
       - name: install cabal-plan
         run: |
           mkdir -p $HOME/.cabal/bin
-          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.6.2.0/cabal-plan-0.6.2.0-x86_64-linux.xz > cabal-plan.xz
-          echo 'de73600b1836d3f55e32d80385acc055fd97f60eaa0ab68a755302685f5d81bc  cabal-plan.xz' | sha256sum -c -
+          curl -sL https://github.com/haskell-hvr/cabal-plan/releases/download/v0.7.3.0/cabal-plan-0.7.3.0-x86_64-linux.xz > cabal-plan.xz
+          echo 'f62ccb2971567a5f638f2005ad3173dba14693a45154c1508645c52289714cb2  cabal-plan.xz' | sha256sum -c -
           xz -d < cabal-plan.xz > $HOME/.cabal/bin/cabal-plan
           rm -f cabal-plan.xz
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -133,7 +165,8 @@ jobs:
       - name: generate cabal.project
         run: |
           PKGDIR_influxdb="$(find "$GITHUB_WORKSPACE/unpacked" -maxdepth 1 -type d -regex '.*/influxdb-[0-9.]*')"
-          echo "PKGDIR_influxdb=${PKGDIR_influxdb}" >> $GITHUB_ENV
+          echo "PKGDIR_influxdb=${PKGDIR_influxdb}" >> "$GITHUB_ENV"
+          rm -f cabal.project cabal.project.local
           touch cabal.project
           touch cabal.project.local
           echo "packages: ${PKGDIR_influxdb}" >> cabal.project
@@ -148,12 +181,12 @@ jobs:
         run: |
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dry-run all
           cabal-plan
-      - name: cache
-        uses: actions/cache@v2
+      - name: restore cache
+        uses: actions/cache/restore@v3
         with:
-          key: ${{ runner.os }}-${{ matrix.ghc }}-${{ github.sha }}
+          key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store
-          restore-keys: ${{ runner.os }}-${{ matrix.ghc }}-
+          restore-keys: ${{ runner.os }}-${{ matrix.compiler }}-
       - name: install dependencies
         run: |
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks --dependencies-only -j2 all
@@ -178,3 +211,9 @@ jobs:
         run: |
           rm -f cabal.project.local
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
+      - name: save cache
+        uses: actions/cache/save@v3
+        if: always()
+        with:
+          key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
+          path: ~/.cabal/store

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -63,11 +63,6 @@ jobs:
             compilerVersion: 8.6.5
             setup-method: hvr-ppa
             allow-failure: false
-          - compiler: ghc-8.4.4
-            compilerKind: ghc
-            compilerVersion: 8.4.4
-            setup-method: hvr-ppa
-            allow-failure: false
       fail-fast: false
     steps:
       - name: apt
@@ -233,7 +228,7 @@ jobs:
           ${CABAL} -vnormal check
       - name: haddock
         run: |
-          $CABAL v2-haddock $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
+          $CABAL v2-haddock --haddock-options=--quickjump $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
       - name: unconstrained build
         run: |
           rm -f cabal.project.local

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -33,6 +33,16 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.4.5
+            compilerKind: ghc
+            compilerVersion: 9.4.5
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.2.8
+            compilerKind: ghc
+            compilerVersion: 9.2.8
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.0.1
             compilerKind: ghc
             compilerVersion: 9.0.1
@@ -64,13 +74,21 @@ jobs:
         run: |
           apt-get update
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git socat software-properties-common libtinfo5
-          apt-add-repository -y 'ppa:hvr/ghc'
-          apt-get update
-          apt-get install -y "$HCNAME"
-          mkdir -p "$HOME/.ghcup/bin"
-          curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
-          chmod a+x "$HOME/.ghcup/bin/ghcup"
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          if [ "${{ matrix.setup-method }}" = ghcup ]; then
+            mkdir -p "$HOME/.ghcup/bin"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
+            chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          else
+            apt-add-repository -y 'ppa:hvr/ghc'
+            apt-get update
+            apt-get install -y "$HCNAME"
+            mkdir -p "$HOME/.ghcup/bin"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
+            chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          fi
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -85,11 +103,20 @@ jobs:
           echo "CABAL_DIR=$HOME/.cabal" >> "$GITHUB_ENV"
           echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
           HCDIR=/opt/$HCKIND/$HCVER
-          HC=$HCDIR/bin/$HCKIND
-          echo "HC=$HC" >> "$GITHUB_ENV"
-          echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
-          echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          if [ "${{ matrix.setup-method }}" = ghcup ]; then
+            HC=$HOME/.ghcup/bin/$HCKIND-$HCVER
+            echo "HC=$HC" >> "$GITHUB_ENV"
+            echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
+            echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          else
+            HC=$HCDIR/bin/$HCKIND
+            echo "HC=$HC" >> "$GITHUB_ENV"
+            echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
+            echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          fi
+
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,0 +1,5 @@
+-- With GHC = 8.4.4 haddock fails due to a parse error in the vector.
+-- https://github.com/haskell/vector/issues/383
+-- And also avoid haddock: internal error: /github/home/.cabal/store/ghc-9.2.8/ghc-paths-0.1.0.12-10a0786baf4e4177a0f0c7bce1c1734610faf216f494e40079fc95c99b6f64e6/share/doc/html/doc-index.json
+-- https://github.com/haskell/cabal/issues/8104
+haddock: >= 9.4

--- a/influxdb.cabal
+++ b/influxdb.cabal
@@ -25,8 +25,10 @@ tested-with:
 
 extra-source-files:
   README.md
-  CHANGELOG.md
   cabal.project
+
+extra-doc-files:
+  CHANGELOG.md
 
 flag examples
   description: Build examples
@@ -36,7 +38,7 @@ flag examples
 custom-setup
  setup-depends:
       base >= 4 && < 5
-    , Cabal >= 1.24
+    , Cabal >= 1.24 && < 3.11
     , cabal-doctest >= 1 && < 1.1
 
 library
@@ -104,7 +106,7 @@ test-suite doctests
       base
     , doctest >= 0.11.3 && < 0.21
     , influxdb
-    , template-haskell
+    , template-haskell < 2.21
   ghc-options: -Wall -threaded
   hs-source-dirs: tests
   default-language: Haskell2010
@@ -117,8 +119,8 @@ test-suite regressions
     , containers
     , influxdb
     , lens
-    , tasty
-    , tasty-hunit
+    , tasty < 1.5
+    , tasty-hunit < 1.11
     , time
     , raw-strings-qq >= 1.1 && < 1.2
     , vector

--- a/influxdb.cabal
+++ b/influxdb.cabal
@@ -15,7 +15,6 @@ copyright: Copyright (C) 2014-2023 Mitsutoshi Aoe
 category: Database
 build-type: Custom
 tested-with:
-  GHC == 8.4.4
   GHC == 8.6.5
   GHC == 8.8.4
   GHC == 8.10.4

--- a/influxdb.cabal
+++ b/influxdb.cabal
@@ -15,6 +15,7 @@ copyright: Copyright (C) 2014-2023 Mitsutoshi Aoe
 category: Database
 build-type: Custom
 tested-with:
+  GHC == 8.4.4
   GHC == 8.6.5
   GHC == 8.8.4
   GHC == 8.10.4

--- a/src/Database/InfluxDB/JSON.hs
+++ b/src/Database/InfluxDB/JSON.hs
@@ -55,6 +55,12 @@ import qualified Data.Vector as V
 
 import Database.InfluxDB.Types
 
+-- $setup
+-- >>> import Data.Maybe
+-- >>> import Data.Aeson (decode)
+-- >>> import Database.InfluxDB.JSON
+-- >>> import qualified Data.Aeson.Types as A
+
 -- | Parse a JSON response with the 'strictDecoder'.
 parseResultsWith
   :: (Maybe Text -> HashMap Text Text -> Vector Text -> Array -> A.Parser a)

--- a/src/Database/InfluxDB/Write/UDP.hs
+++ b/src/Database/InfluxDB/Write/UDP.hs
@@ -31,7 +31,8 @@ import Database.InfluxDB.Types as Types
 This module is desined to be used with the [network]
 (https://hackage.haskell.org/package/network) package and be imported qualified.
 
->>> :set -XOverloadedStrings -XOverloadedLists
+>>> :set -XOverloadedStrings -XNoOverloadedLists
+>>> import qualified Data.Map as Map
 >>> import Data.Time
 >>> import Network.Socket
 >>> import Database.InfluxDB
@@ -39,7 +40,7 @@ This module is desined to be used with the [network]
 >>> sock <- Network.Socket.socket AF_INET Datagram defaultProtocol
 >>> let localhost = tupleToHostAddress (127, 0, 0, 1)
 >>> let params = UDP.writeParams sock $ SockAddrInet 8089 localhost
->>> UDP.write params $ Line "measurement1" [] [("value", FieldInt 42)] (Nothing :: Maybe UTCTime)
+>>> UDP.write params $ Line "measurement1" Map.empty (Map.fromList [("value", FieldInt 42)]) (Nothing :: Maybe UTCTime)
 >>> close sock
 
 Make sure that the UDP service is enabled in the InfluxDB config. This API

--- a/tests/regressions.hs
+++ b/tests/regressions.hs
@@ -37,8 +37,10 @@ case_issue64 = withDatabase dbName $ do
   case r of
     Left err -> case err of
       UnexpectedResponse message _ _ ->
-        message @?=
-          "BUG: parsing Int failed, expected Number, but encountered String in Database.InfluxDB.Query.query"
+        message `elem` [
+          "BUG: parsing Int failed, expected Number, but encountered String in Database.InfluxDB.Query.query",
+          "BUG: expected Int, encountered String in Database.InfluxDB.Query.query"
+        ] @? "Correct error message."
       _ ->
         assertFailure $ got ++ show err
     Right (v :: (V.Vector (Tagged "time" Int, Tagged "value" Int))) ->


### PR DESCRIPTION
Some remarks:
- Regenerated and manually adapted the workflow yaml `haskell-ci.yml`(to include influxdb service & allow localhost access from another container). No further changes - so another regeneration should be easy.
- Removed all warnings from `cabal check` - changes in `influxdb.cabal`
- Added `cabal.haskell.ci` to only build documentation (haddock) on newer GHC's (because older haddock versions don't parse newer code)
- Fixed the doctest I have introduced to be more v2 compatible (changes in `JSON.hs`)
- Avoid `-XOverloadedLists` - this gives very strange results with ghc 9.4.5 - so changed `UDP.hs` (to mimic `Write.hs`)
- Adopted `regressions.hs` to accept parser failure from different aeson versions.

So I think the change-set is relatively straightforward - and I hope ready to merge.

Before a new release is made we should maybe consider supporting ghc 9.6 (in a new PR)?